### PR TITLE
Readme clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
-# tf-rebalance
+# balance.tf
 
-# Balance Mod
+The purpose of this book is to put forth some ideas on how to change some of the items in TF2 that are unbalanced. It focuses on two major things:
 
-Something we'd really like is to turn the changes proposed in this book into a playable mod. We'd host this mod on one or more servers to actually give them some thorough playtesting, therefore giving more credibility to the movement if they turn out well. If you're experienced with this kind of thing and are willing to help us realize it, please contact us in one of the following ways:
+* Giving users a centralized platform to discuss ideas about TF2's balance.
+* Promoting ideas that are consistently approved upon by the community and remain stable for long periods of time.
+
+## Want to Contribute Balance Ideas?
+
+It is highly encouraged for anyone reading this with their own ideas to make a pull request or issue on the [repository](https://github.com/balancetf/balancetf).
+Before you do so, please read **[Contributing](https://github.com/balancetf/balancetf/wiki/Contributing)**. It contains the rules for contributing, templates for PRs and issues, and explains what information is necessary to get your change merged.
+
+## Want to Vote or Participate in Discussion?
+
+If you'd still like to participate in the decision making behind proposed item changes, then join [the discord server](https://discord.gg/7GmCDUP)! Whenever we champion a proposal for approval, we'll have the community vote on it before making a final decision. You can also add in-depth feedback to the Proposal Champion while its being voted on (see [Contributing](https://github.com/balancetf/balancetf/wiki/Contributing)).
+
+## On Bias
+
+It's important to remember that the maintainers are just people with opinions, so disagreements are inevitable. In order to remain as unbiased as possible, changes not yet reviewed either by the community at large or a handful of high level players will be listed as "disputed." Only after review will they be "approved" as the change that is definitely being proposed. **Approved changes are not final**. You are still welcome to propose tweaks to them.
+
+## Approved and Disputed Changes
+
+Something you'll notice throughout this document is the distinction between "Approved" and "Disputed" changes. Essentially, for any given item, there is a theoretically unlimited number of disputed changes. This means that the change has not received signifcant enough review to be approved, or the general consensus is about that change is negative. The default state of a change is disputed. The approval process is based on 2 factors:
+1. Opinions of high level competitive players.
+    * It stands to reason that the best players in the game are the most experienced and are therefore more qualified to judge balance changes than someone with less experience.
+2. Opinions of the community at large.
+    * If the community members participating in this project are generally in favor of a change, that will increase its chances of being championed for approval.
+
+## Balance Mod
+
+Something we'd really like is to turn the changes proposed in this book into a playable mod. We'd host this mod on one or more servers to actually give them some thorough playtesting, therefore giving more credibility to the movement if they turn out well. If you're experienced with this kind of thing and are willing to help us realize it, please contact us:
 
 [Discord](https://discord.gg/7GmCDUP)
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,20 @@
 # Foreword
 
-The purpose of this book is to put forth some ideas on how to change some of the items in TF2 that are unbalanced.
+The purpose of this book is to put forth some ideas on how to change some of the items in TF2 that are unbalanced. It focuses on two major things:
+
+* Giving users a centralized platform to discuss ideas about TF2's balance.
+* Promoting ideas that are consistently approved upon by the community and remain stable for long periods of time.
+
+## Want to Contribute Balance Ideas?
 
 It is highly encouraged for anyone reading this with their own ideas to make a pull request or issue on the [repository](https://github.com/balancetf/balancetf).
 Before you do so, please read **[Contributing](contributing.md)**. It contains the rules for contributing, templates for PRs and issues, and explains what information is necessary to get your change merged.
 
+## Want to Vote or Participate in Discussion?
+
 If you'd still like to participate in the decision making behind proposed item changes, then join [the discord server](https://discord.gg/7GmCDUP)! Whenever we champion a proposal for approval, we'll have the community vote on it before making a final decision. You can also add in-depth feedback to the Proposal Champion while its being voted on (see [Contributing](contributing.md)).
+
+## On Bias
 
 It's important to remember that the maintainers are just people with opinions, so disagreements are inevitable. In order to remain as unbiased as possible, changes not yet reviewed either by the community at large or a handful of high level players will be listed as "disputed." Only after review will they be "approved" as the change that is definitely being proposed. **Approved changes are not final**. You are still welcome to propose tweaks to them.
 


### PR DESCRIPTION
## Changes
- Cleanup the foreword by splitting it up into smaller parts, making it easier to read
- Copy the foreword over to the repo's readme, with small adjustments to ensure hyperlinks go to relevant pages.